### PR TITLE
임시보관함 뷰 새로고침

### DIFF
--- a/Plantory/Plantory/Views/Profile/ProfileViews/TempViews/TempStorageView.swift
+++ b/Plantory/Plantory/Views/Profile/ProfileViews/TempViews/TempStorageView.swift
@@ -137,7 +137,7 @@ struct TempStorageView: View {
     }
 
     private func performDeletion() {
-        viewModel.moveToTrash(ids: Array(checkedItems))
+        viewModel.moveToTrash(ids: Array(checkedItems), sort: isNewSorting ? .latest : .oldest)
         checkedItems.removeAll()
         isEditing = false
         showPopUp = false


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
임시보관함에서 '휴지통으로 보내기' 시 사용자 경험 개선을 위해 다음과 같이 변경했습니다:

- **낙관적 UI 업데이트 적용**: 선택된 항목을 즉시 임시보관함 목록에서 제거하여 사용자에게 빠른 반응성을 제공합니다.
- **삭제 후 목록 재조회**: 휴지통 이동 API 호출 성공 시, 현재 정렬 상태(최신순/오래된순)를 유지하며 서버에서 임시보관함 목록을 재조회하여 최신 상태로 동기화합니다.
- **실패 시 롤백**: API 호출 실패 시, 삭제 전의 목록 상태로 롤백하여 데이터 일관성을 유지합니다.
- 불필요한 로딩 스피너를 제거하여 더 자연스러운 화면 갱신을 구현했습니다.

## 📋 추후 진행 상황
현재 커밋으로 임시보관함 삭제 후 즉시 반영 및 정렬 유지가 완료되었습니다.

## 📌 리뷰 포인트
- 낙관적 업데이트 로직 (즉시 UI 반영 및 실패 시 롤백)이 올바르게 동작하는지 확인해주세요.
- `moveToTrash` 호출 시 정렬 상태(`sort`)가 정확히 전달되고, 재조회에 반영되는지 확인해주세요.
- 에러 발생 시 롤백 처리가 제대로 되는지 확인해주세요.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

---
<a href="https://cursor.com/background-agent?bcId=bc-d588954f-ef42-4dd4-9945-4ba5c1ac8c25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d588954f-ef42-4dd4-9945-4ba5c1ac8c25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

