### PR TITLE
feat: PopupManager, PopupModifier 생성 및 적용

### DIFF
--- a/Plantory/Plantory/Common/UIComponents/Custom/PopUp.swift
+++ b/Plantory/Plantory/Common/UIComponents/Custom/PopUp.swift
@@ -79,7 +79,7 @@ struct BlurBackground: View {
     
     var body: some View {
         Color.black.opacity(0.4)
-            .ignoresSafeArea()
+            .ignoresSafeArea(edges: .all)
             .opacity(blurAmount)
             .onAppear {
                 withAnimation(.easeInOut(duration: 0.1)) {

--- a/Plantory/Plantory/Core/DIContainer/DIContainer.swift
+++ b/Plantory/Plantory/Core/DIContainer/DIContainer.swift
@@ -17,14 +17,19 @@ class DIContainer: ObservableObject {
     /// API 호출을 담당하는 서비스 객체
     @Published var useCaseService: UseCaseService
     
+    /// 선택된 탭을 제어
+    @Published var selectedTab: TabItem
+    
     /// DIContainer 초기화 함수
     /// 외부에서 navigationRouter와 useCaseService를 주입받아 사용할 수 있도록 구성
     /// 기본값으로는 각각 새로운 인스턴스를 생성하여 초기화
     init(
         navigationRouter: NavigationRouter = .init(),
-        useCaseService: UseCaseService = .init()
+        useCaseService: UseCaseService = .init(),
+        selectedTab: TabItem = .home
     ) {
         self.navigationRouter = navigationRouter
         self.useCaseService = useCaseService
+        self.selectedTab = selectedTab
     }
 }

--- a/Plantory/Plantory/Core/Navigation/NavigationRoutingView.swift
+++ b/Plantory/Plantory/Core/Navigation/NavigationRoutingView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 
 /// 앱 내에서 특정 화면으로의 이동을 처리하는 라우팅 뷰입니다.
 struct NavigationRoutingView: View {
-    @StateObject private var container: DIContainer = .init()
-    @State private var isFilterSheetPresented = false
+    @EnvironmentObject var container: DIContainer
+    
     var body: some View {
         NavigationStack(path: $container.navigationRouter.path) {
             LoginView(container: container)
@@ -35,7 +35,7 @@ struct NavigationRoutingView: View {
                             
                         // Tab 뷰
                         case .baseTab:
-                            BaseTabView(terrariumVM: TerrariumViewModel(container: container))
+                            BaseTabView()
                             
                         // 마이페이지
                         case .scrap:

--- a/Plantory/Plantory/Core/Utils/PopupManager.swift
+++ b/Plantory/Plantory/Core/Utils/PopupManager.swift
@@ -1,0 +1,23 @@
+//
+//  PopupManager.swift
+//  Plantory
+//
+//  Created by 주민영 on 9/13/25.
+//
+
+import SwiftUI
+
+final class PopupManager: ObservableObject {
+    @Published var isPresented: Bool = false
+    @Published var popupContent: AnyView = AnyView(EmptyView())
+    
+    func show<Content: View>(@ViewBuilder content: () -> Content) {
+        popupContent = AnyView(content())
+        withAnimation(.linear(duration: 0.15)) { isPresented = true }
+    }
+    
+    func dismiss() {
+        withAnimation(.linear(duration: 0.15)) { isPresented = false }
+        popupContent = AnyView(EmptyView())
+    }
+}

--- a/Plantory/Plantory/Modules/AppFlow/Login/ViewModels/LoginViewModel.swift
+++ b/Plantory/Plantory/Modules/AppFlow/Login/ViewModels/LoginViewModel.swift
@@ -124,7 +124,7 @@ class LoginViewModel {
     
     /// 애플 로그인 API 호출
     private func sendAppleLoginToServer(
-        identityToken: String,
+        identityToken: String
     ) async throws {
         self.isLoading = true
         

--- a/Plantory/Plantory/Modules/AppFlow/Login/Views/ProfileInfoView.swift
+++ b/Plantory/Plantory/Modules/AppFlow/Login/Views/ProfileInfoView.swift
@@ -30,19 +30,17 @@ struct ProfileInfoView: View {
     var body: some View {
         // 메인 콘텐츠
         profileInfoView
-            .overlay {
-                // 로그인 화면으로 돌아가는 팝업
-                if isShowingGoToLoginPopup {
-                    BlurBackground()
-                        .onTapGesture {
-                            withAnimation(.spring()) {
-                                isShowingGoToLoginPopup = false
-                            }
-                        }
-                    
-                    GoToLoginPopup
+            .popup(
+                isPresented: $isShowingGoToLoginPopup,
+                title: "로그인 화면으로 돌아가시겠습니까?",
+                message: "로그인 화면으로 돌아가면 작성 중인 내용이 모두 삭제됩니다.",
+                confirmTitle: "돌아가기",
+                cancelTitle: "취소",
+                onConfirm: {
+                    // 로그인 화면으로 이동한 후 팝업 닫기
+                    container.navigationRouter.reset()
                 }
-            }
+            )
             .toastView(toast: $viewModel.toast)
             .loadingIndicator(viewModel.isLoading)
     }
@@ -155,27 +153,6 @@ struct ProfileInfoView: View {
                 state: $viewModel.genderState
             )
         }
-    }
-    
-    // MARK: - Go To Login Popup
-    /// 로그인으로 돌아가는 팝업뷰
-    private var GoToLoginPopup: some View {
-        PopUp(
-            title: "로그인 화면으로 돌아가시겠습니까?",
-            message: "로그인 화면으로 돌아가면 작성 중인 내용이 모두 삭제됩니다.",
-            confirmTitle: "돌아가기",
-            cancelTitle: "취소",
-            onConfirm: {
-                // 로그인 화면으로 이동한 후 팝업 닫기
-                container.navigationRouter.reset()
-                withAnimation(.spring()) { isShowingGoToLoginPopup = false }
-            },
-            onCancel: {
-                // 팝업 닫기
-                withAnimation(.spring()) { isShowingGoToLoginPopup = false }
-            }
-        )
-        .zIndex(10)
     }
 }
 

--- a/Plantory/Plantory/Modules/Tab/BaseTabView.swift
+++ b/Plantory/Plantory/Modules/Tab/BaseTabView.swift
@@ -9,32 +9,19 @@ import SwiftUI
 
 struct BaseTabView: View {
 
-    // MARK: - Property
-    
-    @StateObject private var tabSelection = TabSelection()
-    
-    @State private var isTerrariumPopupVisible: Bool = false
-    @State private var showFlowerComplete: Bool = false
-    @State private var showPlantPopup = false
-    @State private var selectedTerrariumId: Int? = nil
-    @State private var terrariumVM: TerrariumViewModel
-    @State private var plantPopupVM: PlantPopupViewModel
-
     /// 의존성 주입을 위한 DI 컨테이너
     @EnvironmentObject var container: DIContainer
-
-    init(terrariumVM: TerrariumViewModel) {
-        _terrariumVM = State(initialValue: terrariumVM)
-        _plantPopupVM = State(initialValue: PlantPopupViewModel(container: terrariumVM.container))
-    }
+    
+    /// 팝업을 공통으로 관리하기 위한 Manager
+    @StateObject private var popupManager = PopupManager()
 
     var body: some View {
         ZStack(alignment: .bottom) {
-            TabView(selection: $tabSelection.selectedTab) {
+            TabView(selection: $container.selectedTab) {
                 ForEach(TabItem.allCases, id: \.rawValue) { tab in
                     Tab(
                         "",
-                        image: tabSelection.selectedTab == tab ? "\(tab.rawValue)_fill" : "\(tab.rawValue)",
+                        image: container.selectedTab == tab ? "\(tab.rawValue)_fill" : "\(tab.rawValue)",
                         value: tab,
                         content: {
                             tabView(tab: tab)
@@ -42,68 +29,22 @@ struct BaseTabView: View {
                     )
                 }
             }
-            .allowsHitTesting(!showPlantPopup)
-
-            if isTerrariumPopupVisible {
-                TerrariumPopup(isVisible: $isTerrariumPopupVisible)
-                    .zIndex(10)
-            }
-        }
-        .fullScreenCover(isPresented: $showFlowerComplete, onDismiss: {
-            terrariumVM.fetchTerrarium()
-        }) {
-            FlowerCompleteView(
-                viewModel: terrariumVM,
-                onGoToGarden: {
-                    tabSelection.selectedTab = .terrarium
-                    terrariumVM.selectedTab = .myGarden
-                    showFlowerComplete = false
-                },
-                onGoHome: {
-                    tabSelection.selectedTab = .home
-                    showFlowerComplete = false
-                }
-            )
-            .environmentObject(container)
-            .onAppear {
-                // FlowerCompleteView가 나타날 때 갱신
-                terrariumVM.fetchTerrarium()
-            }
-        }
-        .overlay(alignment: .center) {
-            if showPlantPopup {
+            .allowsHitTesting(!popupManager.isPresented)
+            
+            if popupManager.isPresented {
                 ZStack {
-                    // Dimmed background to block taps behind the popup
-                    Color.black.opacity(0.3)
-                        .ignoresSafeArea()
-
-                    PlantPopupView(
-                        viewModel: plantPopupVM,
-                        onClose: {
-                            // Always return to My Garden tab when the popup closes
-                            terrariumVM.selectedTab = .myGarden
-                            showPlantPopup = false
-                            selectedTerrariumId = nil
-                            plantPopupVM.close()
-                        }
-                    )
-                    .environmentObject(container)
-                    .transition(.opacity.combined(with: .scale))
+                    BlurBackground()
+                        .onTapGesture { withAnimation { popupManager.dismiss() } }
+                    
+                    popupManager.popupContent
+                        .transition(.opacity.combined(with: .scale))
                 }
-                .zIndex(11)
+                .zIndex(99)
             }
         }
         .onAppear {
             UITabBar.appearance().backgroundColor = .white01
             UITabBar.appearance().unselectedItemTintColor = .black01
-        }
-        .onChange(of: showPlantPopup) { oldValue, isPresented in
-            // Whenever the PlantPopupView toggles, force the terrarium internal tab to My Garden
-            terrariumVM.selectedTab = .myGarden
-            if isPresented {
-                // Make sure the main tab is Terrarium when the popup shows
-                tabSelection.selectedTab = .terrarium
-            }
         }
         .ignoresSafeArea(.keyboard)
         .navigationBarBackButtonHidden(true)
@@ -115,39 +56,18 @@ struct BaseTabView: View {
         Group {
             switch tab {
             case .home:
-                HomeView(container:container)
+                HomeView(container: container)
             case .diary:
                 DiaryListView(container: container)
             case .terrarium:
-                TerrariumView(
-                    viewModel: terrariumVM,
-                    onInfoTapped: { isTerrariumPopupVisible = true },
-                    onFlowerComplete: { showFlowerComplete = true },
-                    onPlantTap: { id in
-                        // Ensure Terrarium tab and its internal tab are on My Garden when opening the popup
-                        tabSelection.selectedTab = .terrarium
-                        terrariumVM.selectedTab = .myGarden
-                        selectedTerrariumId = id
-                        plantPopupVM.open(terrariumId: id)
-                        showPlantPopup = true
-                    }
-                )
-
+                TerrariumView(container: container)
             case .chat:
                 ChatView(container: container)
-
             case .profile:
                 MyPageView(container: container)
             }
         }
         .environmentObject(container)
-        .environmentObject(tabSelection)
-    }
-}
-
-class TabSelection: ObservableObject {
-    @Published var selectedTab: TabItem
-    init(selectedTab: TabItem = .home) {
-        self.selectedTab = selectedTab
+        .environmentObject(popupManager)
     }
 }

--- a/Plantory/Plantory/Modules/Tab/DiaryList/Views/DiaryCheckView.swift
+++ b/Plantory/Plantory/Modules/Tab/DiaryList/Views/DiaryCheckView.swift
@@ -151,35 +151,18 @@ struct DiaryCheckView: View {
             UIApplication.shared.hideKeyboard()
             await vm.load()
         }
-        .overlay {
-            if isDeleteSheetPresented {
-                BlurBackground()
-                    .onTapGesture {
-                        withAnimation(.spring()) {
-                            isDeleteSheetPresented = false
-                        }
-                    }
-                
-                PopUp(
-                    title: "일기를 삭제하시겠습니까?",
-                    message: "일기 삭제 시, 일기는 휴지통으로 이동하게 됩니다.",
-                    confirmTitle: "삭제하기",
-                    cancelTitle: "취소",
-                    onConfirm: {
-                        vm.moveToTrash {
-                            // 성공 콜백: 시트 닫고 화면도 필요하면 닫기
-                            isDeleteSheetPresented = false
-                            container.navigationRouter.pop()
-                        }
-                    },
-                    onCancel: {
-                        isDeleteSheetPresented = false
-                    }
-                )
-                .transition(.scale)
-                .zIndex(1)
+        .popup(
+            isPresented: $isDeleteSheetPresented,
+            title: "일기를 삭제하시겠습니까?",
+            message: "일기 삭제 시, 일기는 휴지통으로 이동하게 됩니다.",
+            confirmTitle: "삭제하기",
+            cancelTitle: "취소",
+            onConfirm: {
+                vm.moveToTrash {
+                    container.navigationRouter.pop()
+                }
             }
-        }
+        )
         .toastView(toast: $vm.toast)
         .loadingIndicator(vm.isLoading)
     }

--- a/Plantory/Plantory/Modules/Tab/Profile/Views/DetailProfileView/ProfileManageView.swift
+++ b/Plantory/Plantory/Modules/Tab/Profile/Views/DetailProfileView/ProfileManageView.swift
@@ -24,11 +24,18 @@ struct ProfileManageView: View {
             ScrollView(.vertical, showsIndicators: false) {
                 profileContent
             }
-
-            if isShowingSignOutPopup {
-                signOutPopup
-            }
         }
+        .popup(
+            isPresented: $isShowingSignOutPopup,
+            title: "계정을 탈퇴하시겠습니까?",
+            message: "계정 탈퇴 시, 계정과 관련된 모든 권한과 정보가 삭제됩니다.",
+            confirmTitle: "탈퇴하기",
+            cancelTitle: "취소",
+            onConfirm: {
+                vm.withdrawAccount()
+                container.navigationRouter.reset()
+            }
+        )
         .task {
             UIApplication.shared.hideKeyboard()
         }
@@ -80,31 +87,6 @@ struct ProfileManageView: View {
         Button(action: dismiss.callAsFunction) {
             Image("leftChevron").fixedSize()
         }
-    }
-
-    // MARK: - Sign Out PopUp
-    private var signOutPopup: some View {
-        PopUp(
-            title: "계정을 탈퇴하시겠습니까?",
-            message: "계정 탈퇴 시, 계정과 관련된 모든 권한과 정보가 삭제됩니다.",
-            confirmTitle: "탈퇴하기",
-            cancelTitle: "취소",
-            onConfirm: {
-                vm.withdrawAccount()
-                container.navigationRouter.reset()
-            },
-            onCancel: {
-                withAnimation(.spring()) { isShowingSignOutPopup = false }
-            }
-        )
-        .zIndex(1)
-        .onChange(of: vm.isWithdrawn, initial: false) { _, done in
-                    if done {
-                        isShowingSignOutPopup = false
-                        // 후처리: 세션 정리 & 화면 전환
-                        dismiss()  // 최소 동작: 현재 화면 닫기
-                    }
-                }
     }
 }
 

--- a/Plantory/Plantory/Modules/Tab/Profile/Views/MyPageViews/MyPageView.swift
+++ b/Plantory/Plantory/Modules/Tab/Profile/Views/MyPageViews/MyPageView.swift
@@ -4,7 +4,8 @@ import CombineMoya
 
 // MARK: 메인 뷰
 struct MyPageView: View {
-    private let container: DIContainer
+    @EnvironmentObject var container: DIContainer
+    @EnvironmentObject var popupManager: PopupManager
     
     @State private var showSleepSheet = false
     @State private var showEmotionSheet = false
@@ -18,7 +19,6 @@ struct MyPageView: View {
     @StateObject private var statsVM: MyPageStatsViewModel
     
     init(container: DIContainer) {
-        self.container = container
         _sleepViewModel = StateObject(wrappedValue: SleepStatsViewModel(container: container))
         _statsVM = StateObject(wrappedValue: MyPageStatsViewModel(container: container))
     }
@@ -68,7 +68,21 @@ struct MyPageView: View {
                     trashAction:     { container.navigationRouter.push(.trash) },
                     logoutAction: {
                         // 로그아웃 판넬
-                        withAnimation(.spring()) { showLogout = true }
+                        popupManager.show {
+                            PopUp(
+                                title: "로그아웃 하시겠습니까?",
+                                message: "로그아웃 시, 로그인 화면으로 돌아갑니다.",
+                                confirmTitle: "로그아웃",
+                                cancelTitle: "취소",
+                                onConfirm: {
+                                    statsVM.logout()
+                                    container.navigationRouter.reset()
+                                },
+                                onCancel: {
+                                    popupManager.dismiss()
+                                }
+                            )
+                        }
                     }
                 )
             }
@@ -79,31 +93,6 @@ struct MyPageView: View {
         }
         .sheet(isPresented: $showEmotionSheet) {
             EmotionStatsView(container: container)
-        }
-        .overlay {
-            if showLogout {
-                BlurBackground()
-                    .onTapGesture {
-                        withAnimation(.spring()) { showLogout = false }
-                    }
-                
-                PopUp(
-                    title: "로그아웃 하시겠습니까?",
-                    message: "로그아웃 시, 로그인 화면으로 돌아갑니다.",
-                    confirmTitle: "로그아웃",
-                    cancelTitle: "취소",
-                    onConfirm: {
-                        statsVM.logout()
-                        container.navigationRouter.reset()
-                    },
-                    onCancel: { withAnimation(.spring()) { showLogout = false } }
-                )
-            }
-        }
-        .onChange(of: statsVM.didLogout, initial: false) { _, done in
-            if done {
-                showLogout = false
-            }
         }
         .navigationBarHidden(true)
         .loadingIndicator(statsVM.isLoading)

--- a/Plantory/Plantory/Modules/Tab/Profile/Views/TempViews/TempStorageView.swift
+++ b/Plantory/Plantory/Modules/Tab/Profile/Views/TempViews/TempStorageView.swift
@@ -33,16 +33,14 @@ struct TempStorageView: View {
             .onChange(of: isNewSorting) { _, newValue in
                 viewModel.fetchTemp(sort: newValue ? .latest : .oldest)
             }
-            .overlay {
-                if showPopUp {
-                    BlurBackground()
-                        .onTapGesture {
-                            withAnimation(.spring()) { showPopUp = false }
-                        }
-                    
-                    deleteConfirmationPopUp
-                }
-            }
+            .popup(
+                isPresented: $showPopUp,
+                title: "보관한 일기를 삭제하시겠습니까?",
+                message: "일기 삭제 시, 해당 일기는 휴지통으로 이동합니다.",
+                confirmTitle: "삭제하기",
+                cancelTitle: "취소",
+                onConfirm: performDeletion
+            )
             .customNavigation(
                 title: "임시보관함",
                 leading: navigationLeading,
@@ -119,19 +117,6 @@ struct TempStorageView: View {
             Text(isEditing ? "취소" : "편집")
                 .font(.pretendardRegular(16)).foregroundStyle(.green07)
         }
-    }
-
-    // MARK: - 삭제 확인 팝업
-    private var deleteConfirmationPopUp: some View {
-        PopUp(
-            title: "보관한 일기를 삭제하시겠습니까?",
-            message: "일기 삭제 시, 해당 일기는 휴지통으로 이동합니다.",
-            confirmTitle: "삭제하기",
-            cancelTitle: "취소",
-            onConfirm: performDeletion,
-            onCancel: { withAnimation(.spring()) { showPopUp = false } }
-        )
-        .transition(.scale.combined(with: .opacity))
     }
 
     // MARK: - 액션

--- a/Plantory/Plantory/Modules/Tab/Profile/Views/TrashViews/TrashView.swift
+++ b/Plantory/Plantory/Modules/Tab/Profile/Views/TrashViews/TrashView.swift
@@ -39,25 +39,22 @@ struct TrashView: View {
             trailing: navigationTrailing
         )
         .navigationBarBackButtonHidden(true)
-        .overlay {
-            if showDeletePopUp {
-                BlurBackground()
-                    .onTapGesture {
-                        withAnimation(.spring()) { showDeletePopUp = false }
-                    }
-                
-                deleteConfirmationPopUp
-            }
-            
-            if showRestorePopUp {
-                BlurBackground()
-                    .onTapGesture {
-                        withAnimation(.spring()) { showRestorePopUp = false }
-                    }
-                
-                restoreConfirmationPopUp
-            }
-        }
+        .popup(
+            isPresented: $showDeletePopUp,
+            title: "일기를 삭제하시겠습니까?",
+            message: "일기 삭제 시, 해당 일기는 영구 삭제됩니다.",
+            confirmTitle: "삭제하기",
+            cancelTitle: "취소",
+            onConfirm: performDeletion
+        )
+        .popup(
+            isPresented: $showRestorePopUp,
+            title: "해당 일기를 복원하시겠습니까?",
+            message: "일기 복원 시, 해당 일기는 유지됩니다.",
+            confirmTitle: "복원하기",
+            cancelTitle: "취소",
+            onConfirm: performRestore
+        )
     }
 
     @ViewBuilder
@@ -122,30 +119,6 @@ struct TrashView: View {
             Text(isEditing ? "취소" : "편집")
                 .font(.pretendardRegular(14)).foregroundStyle(.green07)
         }
-    }
-
-    private var deleteConfirmationPopUp: some View {
-        PopUp(
-            title: "일기를 삭제하시겠습니까?",
-            message: "일기 삭제 시, 해당 일기는 영구 삭제됩니다.",
-            confirmTitle: "삭제하기",
-            cancelTitle: "취소",
-            onConfirm: performDeletion,
-            onCancel: { withAnimation(.spring()) { showDeletePopUp = false } }
-        )
-        .transition(.scale.combined(with: .opacity))
-    }
-
-    private var restoreConfirmationPopUp: some View {
-        PopUp(
-            title: "해당 일기를 복원하시겠습니까?",
-            message: "일기 복원 시, 해당 일기는 유지됩니다.",
-            confirmTitle: "복원하기",
-            cancelTitle: "취소",
-            onConfirm: performRestore,
-            onCancel: { withAnimation(.spring()) { showRestorePopUp = false } }
-        )
-        .transition(.scale.combined(with: .opacity))
     }
 
     private func toggleAllSelection() {

--- a/Plantory/Plantory/Modules/Tab/Terrarium/Views/MyGardenContent.swift
+++ b/Plantory/Plantory/Modules/Tab/Terrarium/Views/MyGardenContent.swift
@@ -8,16 +8,16 @@
 import SwiftUI
 
 struct MyGardenContent: View {
+    @EnvironmentObject var container: DIContainer
+    @EnvironmentObject var popupManager: PopupManager
+    
     @State private var viewModel: TerrariumViewModel
     @State private var selectedSegment: String = "나의 정원"
-    @State private var isPlantPopupPresented: Bool = false
     @State private var popupVM: PlantPopupViewModel
-    var onPlantTap: (Int) -> Void
     
-    init(container: DIContainer, onPlantTap: @escaping (Int) -> Void) {
+    init(container: DIContainer) {
         self.viewModel = TerrariumViewModel(container: container)
         self.popupVM = PlantPopupViewModel(container: container)
-        self.onPlantTap = onPlantTap
     }
 
     var body: some View {
@@ -27,7 +27,22 @@ struct MyGardenContent: View {
 
             // 데이터를 제대로 받아왔을 때, PlantListView 표시
             if !viewModel.monthlyTerrariums.isEmpty {
-                PlantListView(items: viewModel.monthlyTerrariums, onPlantTap: onPlantTap)
+                PlantListView(items: viewModel.monthlyTerrariums, onPlantTap: { id in
+                    container.selectedTab = .terrarium
+                    viewModel.selectedTab = .myGarden
+                    popupVM.open(terrariumId: id)
+                    popupManager.show {
+                        PlantPopupView(
+                            viewModel: popupVM,
+                            onClose: {
+                                viewModel.selectedTab = .myGarden
+                                popupManager.dismiss()
+                                popupVM.close()
+                            }
+                        )
+                        .environmentObject(container)
+                    }
+                })
             }
 
             Spacer()
@@ -157,5 +172,5 @@ struct PlantListView: View {
 }
 
 #Preview {
-    MyGardenContent(container: DIContainer(), onPlantTap: { _ in })
+    MyGardenContent(container: DIContainer())
 }

--- a/Plantory/Plantory/Modules/Tab/Terrarium/Views/TerrariumPopup.swift
+++ b/Plantory/Plantory/Modules/Tab/Terrarium/Views/TerrariumPopup.swift
@@ -9,36 +9,34 @@
 import SwiftUI
 
 struct TerrariumPopup: View {
-    @Binding var isVisible: Bool
+    @EnvironmentObject var popupManager: PopupManager
     
     var body: some View {
-        if isVisible {
-            ZStack{
-                Color.black.opacity(0.4)
-                    .edgesIgnoringSafeArea(.all)
-                
-                Image("Tutorial")
-                    .resizable()
-                    .scaledToFill()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .edgesIgnoringSafeArea(.all)
+        ZStack{
+            Color.black.opacity(0.4)
+                .edgesIgnoringSafeArea(.all)
+            
+            Image("Tutorial")
+                .resizable()
+                .scaledToFill()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .edgesIgnoringSafeArea(.all)
 
-                // 닫기 버튼
-                VStack {
-                    HStack {
-                        Spacer()
-                        Button(action: {
-                            isVisible = false
-                        }) {
-                            Image(systemName: "xmark")
-                                .font(.system(size: 48, weight: .light))
-                                .foregroundColor(.white)
-                        }
-                    }
-                    .padding(.top, 47)
-                    .padding(.trailing, 16)
+            // 닫기 버튼
+            VStack {
+                HStack {
                     Spacer()
+                    Button(action: {
+                        popupManager.dismiss()
+                    }) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 48, weight: .light))
+                            .foregroundColor(.white)
+                    }
                 }
+                .padding(.top, 47)
+                .padding(.trailing, 16)
+                Spacer()
             }
         }
     }
@@ -47,6 +45,6 @@ struct TerrariumPopup: View {
 
 struct TerrariumPopup_Previews: PreviewProvider {
     static var previews: some View {
-        TerrariumPopup(isVisible: .constant(true))
+        TerrariumPopup()
     }
 }

--- a/Plantory/Plantory/PlantoryApp.swift
+++ b/Plantory/Plantory/PlantoryApp.swift
@@ -12,6 +12,8 @@ import KakaoSDKAuth
 @main
 struct PlantoryApp: App {
     
+    @StateObject private var container: DIContainer = .init()
+    
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
     init() {
@@ -21,6 +23,7 @@ struct PlantoryApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationRoutingView()
+                .environmentObject(container)
         }
     }
 }

--- a/Plantory/Plantory/Resource/Modifier/PopUpModifier.swift
+++ b/Plantory/Plantory/Resource/Modifier/PopUpModifier.swift
@@ -1,0 +1,75 @@
+//
+//  PopUpModifier.swift
+//  Plantory
+//
+//  Created by 주민영 on 9/11/25.
+//
+
+import SwiftUI
+
+struct PopUpModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    
+    let title: String
+    let message: String
+    let confirmTitle: String
+    let cancelTitle: String
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
+    
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            
+            if isPresented {
+                ZStack {
+                    // 반투명 배경
+                    BlurBackground()
+                        .onTapGesture {
+                            withAnimation { isPresented = false }
+                        }
+                    
+                    // 팝업 본문
+                    PopUp(
+                        title: title,
+                        message: message,
+                        confirmTitle: confirmTitle,
+                        cancelTitle: cancelTitle,
+                        onConfirm: {
+                            onConfirm()
+                            withAnimation { isPresented = false }
+                        },
+                        onCancel: {
+                            onCancel()
+                            withAnimation { isPresented = false }
+                        }
+                    )
+                    .transition(.opacity.combined(with: .scale))
+                }
+                .zIndex(99)
+            }
+        }
+    }
+}
+
+extension View {
+    func popup(
+        isPresented: Binding<Bool>,
+        title: String,
+        message: String,
+        confirmTitle: String = "확인",
+        cancelTitle: String = "취소",
+        onConfirm: @escaping () -> Void = {},
+        onCancel: @escaping () -> Void = {}
+    ) -> some View {
+        self.modifier(PopUpModifier(
+            isPresented: isPresented,
+            title: title,
+            message: message,
+            confirmTitle: confirmTitle,
+            cancelTitle: cancelTitle,
+            onConfirm: onConfirm,
+            onCancel: onCancel
+        ))
+    }
+}

--- a/Plantory/Plantory/Resource/Modifier/PopupModifier.swift
+++ b/Plantory/Plantory/Resource/Modifier/PopupModifier.swift
@@ -1,5 +1,5 @@
 //
-//  PopUpModifier.swift
+//  PopupModifier.swift
 //  Plantory
 //
 //  Created by 주민영 on 9/11/25.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct PopUpModifier: ViewModifier {
+struct PopupModifier: ViewModifier {
     @Binding var isPresented: Bool
     
     let title: String


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용

1. 기존에는 팝업을 `BaseTabView` 위에 띄우기위해 `BaseTabView`에서 사용되는 상태값이 아님에도, `BaseTabView` 파일에 선언되어있던 문제가 있었습니다. 이를 해결하고자 팝업을 공통으로 관리할 수 있는 `PopupManager`를 도입하였습니다.
아래 사진은 기존 문제가 있었던 화면의 사진입니다.
<img height="500" alt="IMG_8980" src="https://github.com/user-attachments/assets/f75aa25a-faf0-4f4e-9877-a29285406942" />

2. 여러 뷰에서 공통으로 `BlurBackground`, `withAnimation { isPresented = false }` 코드를 중복으로 삽입해야하는 번거로움이 있었습니다. 이를 해결하고자 `.popup` 모디파이어를 도입해 리펙토링하였습니다.

3. 탭뷰 선택 상태를 공용 `DIContainer`에서 관리하도록 하였습니다.

* PopupManager는 BaseTabView 위에 팝업을 띄우고자 할 때 사용되며, .popup 모디파이어는 이 외의 상황(BaseTabView 위의 뷰가 아닐 때)에서 사용됩니다.

---

1. `PopupManager` 클래스를 새로 추가하여 앱 전역의 팝업 표시와 콘텐츠를 중앙에서 관리하도록 함
`(Plantory/Plantory/Core/Utils/PopupManager.swift)`
여러 뷰(`ProfileInfoView, DiaryCheckView, ProfileManageView, TempStorageView, TrashView`)를 개별 오버레이/PopUp 뷰 대신 새로운 `.popup` 모디파이어로 교체하여, 팝업 로직 단순화 및 중복 코드 제거

2. 선택된 탭 상태를 `DIContainer`로 이동시켜 앱 전반에서 일관된 탭 선택 관리 가능

3. `@EnvironmentObject`를 활용해 `DIContainer`와 `PopupManager`에 접근하도록 변경하여, 의존성 주입 단순화 및 불필요한 프로퍼티 전달 감소

5. 팝업 닫기/확인 로직을 새 PopupManager와 애니메이션을 활용하도록 바꿔 수동 상태 관리 최소화

6. 더 이상 필요 없는 팝업 관련 코드와 개별 상태 객체를 제거 (TabSelection, 개별 팝업 뷰 빌더 등)

## 📋 추후 진행 상황

## 📌 리뷰 포인트
올바르게 작동하는지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
