### PR TITLE
fix: 로그인, 약관동의뷰 기기대응

### DIFF
--- a/Plantory/Plantory/Common/UIComponents/AdaptiveScrollView.swift
+++ b/Plantory/Plantory/Common/UIComponents/AdaptiveScrollView.swift
@@ -1,0 +1,81 @@
+//
+//  AdaptiveScrollView.swift
+//  Plantory
+//
+//  Created by 주민영 on 9/14/25.
+//
+
+import SwiftUI
+
+/// 스크롤 위치에 따라 상단/하단 패딩을 조절하는 커스텀 ScrollView
+struct AdaptiveScrollView<Content: View>: View {
+    @ViewBuilder let content: Content
+    let topPadding: CGFloat
+    let bottomPadding: CGFloat
+    
+    @State private var topOffset: CGFloat = 0
+    @State private var bottomOffset: CGFloat = 0
+    
+    init(
+        topPadding: CGFloat = 16,
+        bottomPadding: CGFloat = 16,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.topPadding = topPadding
+        self.bottomPadding = bottomPadding
+        self.content = content()
+    }
+    
+    var body: some View {
+        ScrollView {
+            // 스크롤 맨 위 감지
+            GeometryReader { geo in
+                Color.clear
+                    .preference(key: TopOffsetKey.self,
+                                value: geo.frame(in: .named("scroll")).minY)
+            }
+            .frame(height: 0)
+            
+            VStack(spacing: 16) {
+                content
+            }
+            // topOffset이 양수 → 맨 위 도달
+            // bottomOffset이 음수 → 맨 아래 도달
+            .padding(.top, topOffset >= 0 ? topPadding : 0)
+            .padding(.bottom, bottomOffset > 0 ? bottomPadding : 0)
+            
+            // 스크롤 맨 아래 감지
+            GeometryReader { geo in
+                Color.clear
+                    .preference(key: BottomOffsetKey.self,
+                                value: geo.frame(in: .named("scroll")).maxY)
+            }
+            .frame(height: 0)
+        }
+        .coordinateSpace(name: "scroll")
+        .onPreferenceChange(TopOffsetKey.self) { value in
+            // 스크롤 맨 위면 minY가 0, 아래로 내리면 음수로 내려감
+            topOffset = value
+        }
+        .onPreferenceChange(BottomOffsetKey.self) { value in
+            // 뷰포트의 bottom과 ScrollView content bottom 차이를 감지
+            let screenHeight = UIScreen.main.bounds.height
+            bottomOffset = screenHeight - value
+        }
+    }
+}
+
+/// 스크롤 오프셋 감지를 위한 PreferenceKey
+private struct TopOffsetKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+private struct BottomOffsetKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}

--- a/Plantory/Plantory/Modules/AppFlow/Login/ViewModels/LoginViewModel.swift
+++ b/Plantory/Plantory/Modules/AppFlow/Login/ViewModels/LoginViewModel.swift
@@ -111,8 +111,7 @@ class LoginViewModel {
     private func handleLoginSuccess(credential: ASAuthorizationAppleIDCredential) async throws {
         // identityToken, authorizationCode 추출
         guard let identityToken = credential.identityToken,
-              let identityTokenString = String(data: identityToken, encoding: .utf8),
-              let authorizationCode = credential.authorizationCode else {
+              let identityTokenString = String(data: identityToken, encoding: .utf8) else {
             throw NSError(domain: "AppleTokenError", code: -2)
         }
         
@@ -124,7 +123,7 @@ class LoginViewModel {
     
     /// 애플 로그인 API 호출
     private func sendAppleLoginToServer(
-        identityToken: String,
+        identityToken: String
     ) async throws {
         self.isLoading = true
         

--- a/Plantory/Plantory/Modules/AppFlow/Login/Views/LoginView.swift
+++ b/Plantory/Plantory/Modules/AppFlow/Login/Views/LoginView.swift
@@ -27,30 +27,33 @@ struct LoginView: View {
     // MARK: - Body
     
     var body: some View {
-        VStack {
-            logoView
-            
-            Spacer()
-                .frame(maxHeight: 94)
-            
-            VStack(spacing: 22) {
-                loginIndicatorView
-                
-                socialLoginView
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.top, 128)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(
+        ZStack(alignment: .center) {
             RadialGradient(
                 colors: [.white01, .green01],
                 center: .center,
                 startRadius: 0,
                 endRadius: 130
             )
-        )
-        .ignoresSafeArea()
+            .ignoresSafeArea()
+            
+            VStack {
+                Spacer()
+                logoView
+                Spacer()
+                Spacer()
+            }
+            
+            VStack {
+                Spacer()
+                
+                VStack(spacing: 22) {
+                    loginIndicatorView
+                    socialLoginView
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 32)
+            }
+        }
         .navigationBarBackButtonHidden()
         .toastView(toast: $viewModel.toast)
         .loadingIndicator(viewModel.isLoading)
@@ -111,6 +114,15 @@ struct LoginView: View {
     }
 }
 
-#Preview {
-    LoginView(container: .init())
+struct LoginView_Preview: PreviewProvider {
+    static var devices = ["iPhone SE (3rd generation)", "iPhone 11", "iPhone 16 Pro Max"]
+    
+    static var previews: some View {
+        ForEach(devices, id: \.self) { device in
+            LoginView(container: DIContainer())
+                .environment(NavigationRouter())
+                .previewDevice(PreviewDevice(rawValue: device))
+                .previewDisplayName(device)
+        }
+    }
 }

--- a/Plantory/Plantory/Modules/AppFlow/Login/Views/PermitView.swift
+++ b/Plantory/Plantory/Modules/AppFlow/Login/Views/PermitView.swift
@@ -43,7 +43,6 @@ struct PermitView: View {
                     .padding(.top, 44)
                     
                     Spacer()
-                        .frame(height: 168)
                 }
                 
                 MainMiddleButton(
@@ -59,6 +58,8 @@ struct PermitView: View {
                 Spacer()
             }
             .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .padding(.bottom, 24)
         }
         .padding(.top, 10)
         .navigationBarBackButtonHidden(true)
@@ -129,5 +130,7 @@ struct PermitView: View {
 }
 
 #Preview {
-    PermitView(container: DIContainer())
+    NavigationStack {
+        PermitView(container: DIContainer())
+    }
 }

--- a/Plantory/Plantory/Modules/AppFlow/Login/Views/PolicyView.swift
+++ b/Plantory/Plantory/Modules/AppFlow/Login/Views/PolicyView.swift
@@ -18,14 +18,13 @@ struct PolicyView: View {
     }
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             Divider()
                 .foregroundStyle(.gray06)
                 .frame(height: 1)
                 .padding(.top, 8)
-                .padding(.bottom, 20)
             
-            ScrollView {
+            AdaptiveScrollView {
                 Text(termsSections[self.num].body)
                     .kerning(1)
                     .font(.pretendardRegular(14))
@@ -139,4 +138,10 @@ struct PolicyView: View {
         )
     ]
 
+}
+
+#Preview {
+    NavigationStack {
+        PolicyView(num: 1)
+    }
 }

--- a/Plantory/Plantory/Modules/AppFlow/Login/Views/ProfileInfoView.swift
+++ b/Plantory/Plantory/Modules/AppFlow/Login/Views/ProfileInfoView.swift
@@ -48,7 +48,7 @@ struct ProfileInfoView: View {
     }
     
     private var profileInfoView: some View {
-        VStack(spacing: 33) {
+        VStack(spacing: 0) {
             headerView
             
             if viewModel.isCompleted {
@@ -62,13 +62,14 @@ struct ProfileInfoView: View {
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             } else {
-                ScrollView(.vertical, showsIndicators: false) {
+                AdaptiveScrollView(topPadding: 24, bottomPadding: 72) {
                     profileView
                 }
+                .scrollIndicators(.hidden)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .navigationBarBackButtonHidden()
     }
     

--- a/Plantory/Plantory/Modules/Tab/Profile/Views/ScrapView.swift
+++ b/Plantory/Plantory/Modules/Tab/Profile/Views/ScrapView.swift
@@ -94,7 +94,7 @@ struct ScrapView: View {
             }
         }
         .customNavigation(
-            title: "휴지통",
+            title: "스크랩",
             leading: Button(action: { container.navigationRouter.pop()
             }, label: {
                 Image("leftChevron").fixedSize()
@@ -154,5 +154,7 @@ struct ScrapView: View {
 }
 
 #Preview {
-    ScrapView(container: DIContainer())
+    NavigationStack {
+        ScrapView(container: DIContainer())
+    }
 }


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
1. 로그인, 약관동의뷰 기기대응
- 기존에 iPhone SE에서 기기대응이 깨져 애플로그인 버튼을 누를 수 없는 문제가 있었습니다. 이를 수정하고 로그인, 약관동의뷰가 모든 기기에서 자연스럽게 보이도록 수정하였습니다.

|iPhone SE|iPhone  11|iPhone 16 pro max|
|---|---|---|
|<img height="350" alt="login-SE" src="https://github.com/user-attachments/assets/10e1d576-fa5a-4b84-897b-11dc4fe66b23" />|<img height="350" alt="login-11" src="https://github.com/user-attachments/assets/8a448040-4e19-4669-812a-aaaaadbded91" />|<img height="350" alt="login-16-pro-max" src="https://github.com/user-attachments/assets/3163d496-6bcb-4910-bb84-f27f60a50021" />|

2. 약관 상세, 초기 프로필 설정 뷰에 `AdaptiveScrollView` 적용
- 기존 스크롤뷰에 패딩을 적용하면 스크롤을 내려도 본문이 패딩에 짤려보이는 문제가 있었습니다. 이를 해결하고자 `AdaptiveScrollView` 컴포넌트를 추가하여 스크롤을 내리면 패딩이 없어지도록 수정하여 좀 더 자연스러운 화면이 되도록 하였습니다.

|문제 해결 전|문제 해결 후|
|---|---|
|<img height="350" alt="login-SE" src="https://github.com/user-attachments/assets/0748fdc8-9133-47c5-898e-77f5c32b2e6b" />|<img height="350" alt="login-11" src="https://github.com/user-attachments/assets/363e61e1-0909-4f1a-80ed-a045bb71d5ea" />|

3. 채팅이 없는 경우의 뷰 추가
기존에는 기록된 채팅이 없는 경우 그냥 빈화면이 떴지만 빈화면임을 알려주는 `NothingView`를 추가하였습니다.

<img  height="350" alt="스크린샷 2025-09-14 오후 3 47 30" src="https://github.com/user-attachments/assets/e4bd212b-7015-4861-8ca8-7f27b1002fd2" />

4. 안쓰는 변수 제거 및 오타 수정
`LoginViewModel`의 `identityTokenString` 변수는 사용하지않아 제거하였습니다.
`ScrapView`의 네비게이션바의 타이틀이 휴지통으로 잘못기입되어있어 스크랩으로 수정하였습니다.

## 📌 리뷰 포인트
기기대응 안깨지는지 확인
위 수정사항들 모두 일치하는지 확인


## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
