### PR TITLE
feat: 자동로그인 추가 및 코멘트 API 연결

### DIFF
--- a/Plantory/Plantory.xcodeproj/project.pbxproj
+++ b/Plantory/Plantory.xcodeproj/project.pbxproj
@@ -174,7 +174,7 @@
 		C05ECEF62E1523300023AC5C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = C05ECEEF2E15232F0023AC5C /* Plantory */;
-			baseConfigurationReferenceRelativePath = Secret.xcconfig;
+			baseConfigurationReferenceRelativePath = Core/Utils/Secret.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -241,7 +241,7 @@
 		C05ECEF72E1523300023AC5C /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = C05ECEEF2E15232F0023AC5C /* Plantory */;
-			baseConfigurationReferenceRelativePath = Secret.xcconfig;
+			baseConfigurationReferenceRelativePath = Core/Utils/Secret.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -300,8 +300,6 @@
 		};
 		C05ECEF92E1523300023AC5C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReferenceAnchor = C05ECEEF2E15232F0023AC5C /* Plantory */;
-			baseConfigurationReferenceRelativePath = Secret.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -319,7 +317,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -333,14 +331,12 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
 		C05ECEFA2E1523300023AC5C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReferenceAnchor = C05ECEEF2E15232F0023AC5C /* Plantory */;
-			baseConfigurationReferenceRelativePath = Secret.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -357,8 +353,8 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-        INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -372,7 +368,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Plantory/Plantory.xcodeproj/xcshareddata/xcschemes/Plantory.xcscheme
+++ b/Plantory/Plantory.xcodeproj/xcshareddata/xcschemes/Plantory.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C05ECEEC2E15232F0023AC5C"
+               BuildableName = "Plantory.app"
+               BlueprintName = "Plantory"
+               ReferencedContainer = "container:Plantory.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C05ECEEC2E15232F0023AC5C"
+            BuildableName = "Plantory.app"
+            BlueprintName = "Plantory"
+            ReferencedContainer = "container:Plantory.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C05ECEEC2E15232F0023AC5C"
+            BuildableName = "Plantory.app"
+            BlueprintName = "Plantory"
+            ReferencedContainer = "container:Plantory.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Plantory/Plantory/Common/Enum/DiaryList/ReplyState.swift
+++ b/Plantory/Plantory/Common/Enum/DiaryList/ReplyState.swift
@@ -1,0 +1,13 @@
+//
+//  ReplyState.swift
+//  Plantory
+//
+//  Created by 주민영 on 9/30/25.
+//
+
+//ai 답장 생성 상태
+enum ReplyState {
+    case loading //로딩중
+    case arrived // ai답장 생성 완료
+    case complete // ai답장 확인
+}

--- a/Plantory/Plantory/Core/Navigation/NavigationDestination.swift
+++ b/Plantory/Plantory/Core/Navigation/NavigationDestination.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-enum NavigationDestination: Equatable, Hashable{
-    case login
+enum NavigationDestination: Equatable, Hashable {
     case permit
     case policy(num: Int)
     case profileInfo

--- a/Plantory/Plantory/Core/Navigation/NavigationRoutingView.swift
+++ b/Plantory/Plantory/Core/Navigation/NavigationRoutingView.swift
@@ -24,8 +24,6 @@ struct NavigationRoutingView: View {
                     Group {
                         switch destination {
                         // 로그인, 회원가입 뷰
-                        case .login:
-                            LoginView(container: container, sessionManager: sessionManager)
                         case .permit:
                             PermitView(container: container)
                         case .policy(let num):

--- a/Plantory/Plantory/Core/Navigation/NavigationRoutingView.swift
+++ b/Plantory/Plantory/Core/Navigation/NavigationRoutingView.swift
@@ -7,28 +7,32 @@
 
 
 import SwiftUI
+import FirebaseMessaging
 
 
 /// 앱 내에서 특정 화면으로의 이동을 처리하는 라우팅 뷰입니다.
 struct NavigationRoutingView: View {
     @EnvironmentObject var container: DIContainer
+    @EnvironmentObject var sessionManager: SessionManager
     
     var body: some View {
         NavigationStack(path: $container.navigationRouter.path) {
-            LoginView(container: container)
+            BaseTabView()
                 .environmentObject(container)
+                .environmentObject(sessionManager)
                 .navigationDestination(for: NavigationDestination.self) { destination in
                     Group {
                         switch destination {
                         // 로그인, 회원가입 뷰
                         case .login:
-                            LoginView(container: container)
+                            LoginView(container: container, sessionManager: sessionManager)
                         case .permit:
                             PermitView(container: container)
                         case .policy(let num):
                             PolicyView(num: num)
                         case .profileInfo:
                             ProfileInfoView(container: container)
+                                .environmentObject(sessionManager)
                             
                         case .addDiary(let date):
                             AddDiaryView(container: container, date: date)
@@ -48,6 +52,7 @@ struct NavigationRoutingView: View {
                             EmotionStatsView(container: container)
                         case .profileManage:
                             ProfileManageView(container: container)
+                                .environmentObject(sessionManager)
                             
                         case .diarySearch:
                             DiarySearchView(container: container)
@@ -61,6 +66,15 @@ struct NavigationRoutingView: View {
                 }
         }
         .environmentObject(container)
+        .onAppear {
+            Messaging.messaging().token { token, error in
+              if let error = error {
+                print("Error fetching FCM registration token: \(error)")
+              } else if let token = token {
+                print("FCM registration token: \(token)")
+              }
+            }
+        }
     }
 }
 

--- a/Plantory/Plantory/Models/DTO/Diary/DiaryDTO.swift
+++ b/Plantory/Plantory/Models/DTO/Diary/DiaryDTO.swift
@@ -11,6 +11,7 @@ struct DiarySummary: Codable, Identifiable {
     let emotion: EmotionDisplay
     let content: String
     let diaryImgUrl: String?
+    let aiComment: String?
     
     // Identifiable 요구사항
     var id: Int { diaryId }

--- a/Plantory/Plantory/Models/Domain/DiaryList/ReplyStateData.swift
+++ b/Plantory/Plantory/Models/Domain/DiaryList/ReplyStateData.swift
@@ -1,0 +1,19 @@
+//
+//  ReplyState.swift
+//  Plantory
+//
+//  Created by 주민영 on 9/30/25.
+//
+
+import SwiftData
+
+@Model
+class ReplyStateData {
+    @Attribute(.unique) var id: Int
+    var isOpened: Bool
+    
+    init(id: Int, isOpened: Bool = false) {
+        self.id = id
+        self.isOpened = isOpened
+    }
+}

--- a/Plantory/Plantory/Modules/AppFlow/Login/ViewModels/LoginViewModel.swift
+++ b/Plantory/Plantory/Modules/AppFlow/Login/ViewModels/LoginViewModel.swift
@@ -29,13 +29,18 @@ class LoginViewModel {
     /// Combine 구독 해제를 위한 Set
     var cancellables = Set<AnyCancellable>()
     
+    /// 자동 로그인 관리
+    let sessionManager: SessionManager
+    
     // MARK: - Init
         
     /// ViewModel 초기화
     /// - Parameters:
     ///   - container: DIContainer를 주입받아 서비스 사용
-    init(container: DIContainer) {
+    ///   - sessionManager: SessionManager를 주입받아 사용
+    init(container: DIContainer, sessionManager: SessionManager) {
         self.container = container
+        self.sessionManager = sessionManager
     }
     
     // MARK: - ManagerProperty
@@ -89,6 +94,7 @@ class LoginViewModel {
                     await self?.routeAfterLogin(status: response.memberStatus)
                 }
 
+                self?.sessionManager.isLoggedIn = response.memberStatus == .active
                 self?.isLoading = false
             })
             .store(in: &cancellables)
@@ -151,7 +157,8 @@ class LoginViewModel {
                 Task {
                     await self?.routeAfterLogin(status: response.memberStatus)
                 }
-
+                
+                self?.sessionManager.isLoggedIn = response.memberStatus == .active
                 self?.isLoading = false
             })
             .store(in: &cancellables)
@@ -167,7 +174,7 @@ class LoginViewModel {
         case .agree:
             container.navigationRouter.push(.profileInfo)
         case .active:
-            container.navigationRouter.push(.baseTab)
+            break
         }
     }
 }

--- a/Plantory/Plantory/Modules/AppFlow/Login/Views/LoginView.swift
+++ b/Plantory/Plantory/Modules/AppFlow/Login/Views/LoginView.swift
@@ -19,9 +19,10 @@ struct LoginView: View {
 
     /// DIContainer를 주입받아 초기화
     init(
-        container: DIContainer
+        container: DIContainer,
+        sessionManager: SessionManager
     ) {
-        self.viewModel = .init(container: container)
+        self.viewModel = .init(container: container, sessionManager: sessionManager)
     }
     
     // MARK: - Body
@@ -119,7 +120,7 @@ struct LoginView_Preview: PreviewProvider {
     
     static var previews: some View {
         ForEach(devices, id: \.self) { device in
-            LoginView(container: DIContainer())
+            LoginView(container: DIContainer(), sessionManager: SessionManager())
                 .environment(NavigationRouter())
                 .previewDevice(PreviewDevice(rawValue: device))
                 .previewDisplayName(device)

--- a/Plantory/Plantory/Modules/AppFlow/Login/Views/ProfileInfoView.swift
+++ b/Plantory/Plantory/Modules/AppFlow/Login/Views/ProfileInfoView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ProfileInfoView: View {
     
     @EnvironmentObject var container: DIContainer
+    @EnvironmentObject var sessionManager: SessionManager
     
     // MARK: - Property
     
@@ -22,7 +23,9 @@ struct ProfileInfoView: View {
 
     /// DIContainer와 앱 흐름 ViewModel(AppFlowViewModel)을 주입받아 초기화
     init(container: DIContainer) {
-        _viewModel = StateObject(wrappedValue: ProfileInfoViewModel(container: container))
+        _viewModel = StateObject(
+            wrappedValue: ProfileInfoViewModel(container: container)
+        )
     }
     
     // MARK: - Body
@@ -55,7 +58,7 @@ struct ProfileInfoView: View {
                     subText: "플랜토리의 다양한 서비스를 이용해보세요.",
                     buttonTitle: "홈으로 이동하기",
                     buttonAction: {
-                        container.navigationRouter.push(.baseTab)
+                        sessionManager.isLoggedIn = true
                     }
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)

--- a/Plantory/Plantory/Modules/RootView.swift
+++ b/Plantory/Plantory/Modules/RootView.swift
@@ -1,0 +1,59 @@
+//
+//  RootView.swift
+//  Plantory
+//
+//  Created by 주민영 on 9/30/25.
+//
+
+import SwiftUI
+
+struct RootView: View {
+    @AppStorage("lastResetDate") private var lastResetDate: Date?
+    
+    @AppStorage("isLoggedIn") var isLoggedIn: Bool = false
+    
+    @Environment(\.modelContext) private var context
+    @EnvironmentObject var container: DIContainer
+    @EnvironmentObject var sessionManager: SessionManager
+    
+    var body: some View {
+        Group {
+            if sessionManager.isLoggedIn {
+                NavigationRoutingView()
+                   .environmentObject(container)
+                   .environmentObject(sessionManager)
+            } else {
+                LoginView(container: container, sessionManager: sessionManager)
+            }
+        }
+        .animation(.easeInOut, value: sessionManager.isLoggedIn)
+        .onAppear {
+            resetIfNeeded()
+        }
+    }
+    
+    private func resetIfNeeded() {
+        let now = Date()
+        
+        if let last = lastResetDate {
+            if let days = Calendar.current.dateComponents([.day], from: last, to: now).day,
+               days >= 30 {
+                resetDatabase()
+                lastResetDate = now
+            }
+        } else {
+            // 최초 실행 → 초기화 날짜 기록만
+            lastResetDate = now
+        }
+    }
+    
+    private func resetDatabase() {
+        do {
+            try context.delete(model: ReplyStateData.self)
+            try context.save()
+            print("SwiftData 초기화 완료")
+        } catch {
+            print("초기화 실패: \(error)")
+        }
+    }
+}

--- a/Plantory/Plantory/Modules/Tab/BaseTabView.swift
+++ b/Plantory/Plantory/Modules/Tab/BaseTabView.swift
@@ -12,6 +12,8 @@ struct BaseTabView: View {
     /// 의존성 주입을 위한 DI 컨테이너
     @EnvironmentObject var container: DIContainer
     
+    @EnvironmentObject var sessionManager: SessionManager
+    
     /// 팝업을 공통으로 관리하기 위한 Manager
     @StateObject private var popupManager = PopupManager()
 
@@ -65,6 +67,7 @@ struct BaseTabView: View {
                 ChatView(container: container)
             case .profile:
                 MyPageView(container: container)
+                    .environmentObject(sessionManager)
             }
         }
         .environmentObject(container)

--- a/Plantory/Plantory/Modules/Tab/DiaryList/ViewModels/DiaryCheckViewModel.swift
+++ b/Plantory/Plantory/Modules/Tab/DiaryList/ViewModels/DiaryCheckViewModel.swift
@@ -6,12 +6,14 @@
 //
 
 import SwiftUI
+import SwiftData
 import Combine
 
 @MainActor
 final class DiaryCheckViewModel: ObservableObject {
     private enum DiaryStatus: String { case normal = "NORMAL", temp = "TEMP", scrap = "SCRAP", trash = "TRASH" }
     
+    @Published var nickname: String = ""
     @Published var summary: DiarySummary?
     
     @Published var toast: CustomToast? = nil
@@ -27,6 +29,8 @@ final class DiaryCheckViewModel: ObservableObject {
     private let container: DIContainer
     private var cancellables = Set<AnyCancellable>()
     
+    var context: ModelContext?
+    
     init(diaryId: Int, container: DIContainer) {
         self.diaryId = diaryId
         self.container = container
@@ -36,6 +40,8 @@ final class DiaryCheckViewModel: ObservableObject {
     
     @Published var selectedImage: UIImage?
     @Published var didDeleteProfileImage: Bool = false
+    
+    @Published var state: ReplyState? = nil
     
     // MARK: - 함수
     
@@ -59,8 +65,65 @@ final class DiaryCheckViewModel: ObservableObject {
         }
     }
     
+    // SwiftData에 저장된 isOpened 불러오기
+    private func isReplyOpened(id: Int) -> Bool {
+        let descriptor = FetchDescriptor<ReplyStateData>(
+            predicate: #Predicate { $0.id == id }
+        )
+        if let state = try? context?.fetch(descriptor).first {
+            return state.isOpened
+        }
+        return false
+    }
+    
+    // 조건을 바탕으로 ReplyState 결정
+    private func determineState(from summary: DiarySummary) -> ReplyState? {
+        if summary.status == "TEMP", summary.aiComment == "임시 코멘트" {
+            return nil
+        } else if summary.aiComment == "임시 코멘트" {
+            return .loading
+        } else if isReplyOpened(id: summary.diaryId) {
+            return .complete
+        } else {
+            return .arrived
+        }
+    }
+    
+    // isOpened를 true로 변경
+    func saveAsOpened() {
+        guard let replyId = summary?.diaryId else { return }
+        
+        let descriptor = FetchDescriptor<ReplyStateData>(
+            predicate: #Predicate { $0.id == replyId }
+        )
+        
+        // id가 DB에 없으면 insert
+        if (try? context?.fetch(descriptor).first) == nil {
+            context?.insert(ReplyStateData(id: replyId, isOpened: true))
+            try? context?.save()
+        }
+    }
+    
     
     // MARK: - API
+    
+    //닉네임 불러오는 API
+    func fetchNickname() async {
+        self.isLoading = true
+        
+        container.useCaseService.profileService
+            .fetchProfileStats()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] completion in
+                guard let self = self else { return }
+                self.isLoading = false
+            } receiveValue: { [weak self] r in
+                guard let self else { return }
+                self.nickname = r.nickname
+                self.isLoading = false
+            }
+            .store(in: &cancellables)
+    }
     
     //일기 불러오는 API
     func load() async {
@@ -80,6 +143,8 @@ final class DiaryCheckViewModel: ObservableObject {
             } receiveValue: { [weak self] summary in
                 self?.summary = summary
                 self?.editedContent = summary.content
+                self?.isSaving = summary.status == "TEMP"
+                self?.state = self?.determineState(from: summary)
             }
             .store(in: &cancellables)
     }

--- a/Plantory/Plantory/Modules/Tab/Home/Views/AddDiary/CompletedView.swift
+++ b/Plantory/Plantory/Modules/Tab/Home/Views/AddDiary/CompletedView.swift
@@ -7,11 +7,6 @@
 
 import SwiftUI
 
-// 테라리움 탭으로 전환 신호
-extension Notification.Name {
-    static let switchToTerrariumTab = Notification.Name("SwitchToTerrariumTab")
-}
-
 struct CompletedView: View {
     @EnvironmentObject var container: DIContainer
 
@@ -26,7 +21,6 @@ struct CompletedView: View {
                     Button(
                         action: {
                             container.navigationRouter.reset()
-                            container.navigationRouter.push(.baseTab)
                         }
                     ) {
                         Image(.home)
@@ -57,11 +51,8 @@ struct CompletedView: View {
                         action: {
                             // 1) 베이스 탭으로 이동
                             container.navigationRouter.reset()
-                            container.navigationRouter.push(.baseTab)
                             // 2) 테라리움 탭 전환 신호
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                                NotificationCenter.default.post(name: .switchToTerrariumTab, object: nil)
-                            }
+                            container.selectedTab = .terrarium
                         }
                     )
 

--- a/Plantory/Plantory/Modules/Tab/Profile/Views/DetailProfileView/ProfileManageView.swift
+++ b/Plantory/Plantory/Modules/Tab/Profile/Views/DetailProfileView/ProfileManageView.swift
@@ -5,6 +5,7 @@ import UIKit
 struct ProfileManageView: View {
     private let container: DIContainer
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var sessionManager: SessionManager
 
     @StateObject private var vm: ProfileViewModel
 
@@ -34,6 +35,7 @@ struct ProfileManageView: View {
             onConfirm: {
                 vm.withdrawAccount()
                 container.navigationRouter.reset()
+                sessionManager.isLoggedIn = false
             }
         )
         .task {

--- a/Plantory/Plantory/Modules/Tab/Profile/Views/MyPageViews/MyPageView.swift
+++ b/Plantory/Plantory/Modules/Tab/Profile/Views/MyPageViews/MyPageView.swift
@@ -6,6 +6,7 @@ import CombineMoya
 struct MyPageView: View {
     @EnvironmentObject var container: DIContainer
     @EnvironmentObject var popupManager: PopupManager
+    @EnvironmentObject var sessionManager: SessionManager
     
     @State private var showSleepSheet = false
     @State private var showEmotionSheet = false
@@ -77,6 +78,7 @@ struct MyPageView: View {
                                 onConfirm: {
                                     statsVM.logout()
                                     container.navigationRouter.reset()
+                                    sessionManager.isLoggedIn = false
                                 },
                                 onCancel: {
                                     popupManager.dismiss()

--- a/Plantory/Plantory/Modules/Tab/Profile/Views/MyPageViews/MyPageView.swift
+++ b/Plantory/Plantory/Modules/Tab/Profile/Views/MyPageViews/MyPageView.swift
@@ -88,6 +88,7 @@ struct MyPageView: View {
             }
             .padding(.vertical, 24)
         }
+        .scrollIndicators(.hidden)
         .sheet(isPresented: $showSleepSheet) {
             SleepStatsView(container: container)
         }

--- a/Plantory/Plantory/Modules/Tab/Profile/Views/TempViews/TempStorageView.swift
+++ b/Plantory/Plantory/Modules/Tab/Profile/Views/TempViews/TempStorageView.swift
@@ -89,7 +89,9 @@ struct TempStorageView: View {
                                 }
                             }
                         ),
-                        onNavigate: {}
+                        onNavigate: {
+                            container.navigationRouter.push(.diaryDetail(diaryId: cell.id))
+                        }
                     )
                     .frame(maxWidth: .infinity)
                 }

--- a/Plantory/Plantory/PlantoryApp.swift
+++ b/Plantory/Plantory/PlantoryApp.swift
@@ -14,6 +14,8 @@ struct PlantoryApp: App {
     
     @StateObject private var container: DIContainer = .init()
     
+    @StateObject private var sessionManager = SessionManager()
+    
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
     init() {
@@ -22,8 +24,14 @@ struct PlantoryApp: App {
     
     var body: some Scene {
         WindowGroup {
-            NavigationRoutingView()
-                           .environmentObject(container)
+            RootView()
+               .environmentObject(container)
+               .environmentObject(sessionManager)
+               .onReceive(NotificationCenter.default.publisher(for: .sessionExpired)) { _ in
+                   // refresh 실패 → 자동 로그아웃 처리
+                   sessionManager.logout()
+               }
         }
+        .modelContainer(for: ReplyStateData.self)
     }
 }

--- a/Plantory/Plantory/Resource/Extension/NotificationName+Extension.swift
+++ b/Plantory/Plantory/Resource/Extension/NotificationName+Extension.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationName+Extension.swift
+//  Plantory
+//
+//  Created by 주민영 on 9/30/25.
+//
+
+import SwiftUI
+
+extension Notification.Name {
+    static let sessionExpired = Notification.Name("sessionExpired")
+}

--- a/Plantory/Plantory/Resource/Modifier/LoadingIndicatorModifier.swift
+++ b/Plantory/Plantory/Resource/Modifier/LoadingIndicatorModifier.swift
@@ -45,6 +45,6 @@ extension View {
 
 
 #Preview {
-    LoginView(container: .init())
+    LoginView(container: .init(), sessionManager: .init())
 }
 

--- a/Plantory/Plantory/Service/Common/APITargetType.swift
+++ b/Plantory/Plantory/Service/Common/APITargetType.swift
@@ -23,5 +23,7 @@ extension APITargetType {
         }
     }
     
-    var validationType: ValidationType { .none }
+    var validationType: ValidationType {
+        return .customCodes((100..<600).filter { $0 != 401 })
+    }
 }

--- a/Plantory/Plantory/Service/Token/SessionManager.swift
+++ b/Plantory/Plantory/Service/Token/SessionManager.swift
@@ -1,0 +1,19 @@
+//
+//  SessionManager.swift
+//  Plantory
+//
+//  Created by 주민영 on 9/30/25.
+//
+
+import SwiftUI
+import Combine
+
+class SessionManager: ObservableObject {
+    @AppStorage("isLoggedIn") var isLoggedIn: Bool = false
+    
+    func logout() {
+        DispatchQueue.main.async {
+            self.isLoggedIn = false
+        }
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용

- 임시보관함에서도 일기 상세뷰 들어갈 수 있도록 추가하여 수정이 가능하도록 변경하였습니다.
- 마이페이지뷰의 스크롤바를 숨김 처리 하였습니다.
- 자동 로그인을 추가하여 기존에 로그인 된 상태라면 로그인 과정을 생략할 수 있도록 하였습니다.
  - accessToken 만료 시, 자동으로 refreshToken으로 accessToken을 불러옵니다.
  - refreshToken 만료 시, 로그인 페이지로 이동합니다.
  - 이제 로그인 페이지로 이동하려고 한다면, sessionManager의 isLoggedIn를 false로 설정해야합니다. 또한 navigation으로는 로그인 페이지로 이동할 수 없습니다.
- AI 코멘트 부분의 API 연결을 완료했습니다. 초기에 임시 코멘트로 서버에서 받아오는 경우, 로딩 뷰로 띄워집니다. 코멘트가 입력된 경우(== 임시 코멘트가 아님)에는 도착했다는 뷰가 뜨며 조회한 경우 메시지가 뜹니다. 조회한 경우는 스위프트 데이터에 id와 같이 저장하여 다음에 일기 상세뷰를 조회했을 경우에 열려있도록 수정하였습니다. 또한 SwiftData가 30일마다 초기화되도록 하였습니다.

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
